### PR TITLE
Toggle to show Replay Box

### DIFF
--- a/weiss2-real-multiple-layouts.mse-style/style
+++ b/weiss2-real-multiple-layouts.mse-style/style
@@ -85,6 +85,11 @@ styling field:
 	choice: long trait
 	choice: triple trait
 	description: Determines the style of the trait boxes. Do note that, for long trait style, the IMS format is used instead of the Fubuki format. Note that entering any trait in the third trait locks you to triple trait style, regardless of this value.
+styling field:
+	type: boolean
+	name: show replay
+	description: Show the replay text box
+	initial: no
 
 card style:
 	color:
@@ -515,7 +520,8 @@ card style:
 			}
 		width: 
 			{
-				if card.card_type == "character" or card.card_type == "event" then 394 - 14 + 2
+				if not styling.show_replay then 0
+				else if card.card_type == "character" or card.card_type == "event" then 394 - 14 + 2
 				else if card.card_type == "climax" then 204 - 14 + 2
 				# previous was 209
 			}
@@ -1107,7 +1113,7 @@ extra card style:
 				else if card.card_type == "climax" then 270
 			}
 		render style: image
-		visible: { card.replay_text != "" }
+		visible: { styling.show_replay and card.replay_text != "" }
 		choice images:
 			default: bars\replay_border.png
 	replay bar 2:
@@ -1130,7 +1136,7 @@ extra card style:
 				else if card.card_type == "climax" then 270
 			}
 		render style: image
-		visible: { card.replay_text != "" }
+		visible: { styling.show_replay and card.replay_text != "" }
 		choice images:
 			default: bars\replay_border.png
 	replay bar 3:
@@ -1153,7 +1159,7 @@ extra card style:
 				else if card.card_type == "climax" then 270
 			}
 		render style: image
-		visible: { card.replay_text != "" }
+		visible: { styling.show_replay and card.replay_text != "" }
 		choice images:
 			default: bars\replay_border.png
 	replay bar 4:
@@ -1176,7 +1182,7 @@ extra card style:
 				else if card.card_type == "climax" then 270
 			}
 		render style: image
-		visible: { card.replay_text != "" }
+		visible: { styling.show_replay and card.replay_text != "" }
 		choice images:
 			default: bars\replay_border.png
 	## ## ## ## ## ##
@@ -1355,7 +1361,8 @@ extra card style:
 			}
 		width: 
 			{
-				if card.card_type == "character" or card.card_type == "event" then 394 - 14 + 2
+				if not styling.show_replay then 0
+				else if card.card_type == "character" or card.card_type == "event" then 394 - 14 + 2
 				else if card.card_type == "climax" then 204 - 14 + 2
 				# previous was 209
 			}
@@ -1393,7 +1400,8 @@ extra card style:
 			}
 		width: 
 			{
-				if card.card_type == "character" or card.card_type == "event" then 394 - 14 + 2
+				if not styling.show_replay then 0
+				else if card.card_type == "character" or card.card_type == "event" then 394 - 14 + 2
 				else if card.card_type == "climax" then 204 - 14 + 2
 				# previous was 209
 			}
@@ -1431,7 +1439,8 @@ extra card style:
 			}
 		width: 
 			{
-				if card.card_type == "character" or card.card_type == "event" then 394 - 14 + 2
+				if not styling.show_replay then 0
+				else if card.card_type == "character" or card.card_type == "event" then 394 - 14 + 2
 				else if card.card_type == "climax" then 204 - 14 + 2
 				# previous was 209
 			}
@@ -1469,7 +1478,8 @@ extra card style:
 			}
 		width: 
 			{
-				if card.card_type == "character" or card.card_type == "event" then 394 - 14 + 2
+				if not styling.show_replay then 0
+				else if card.card_type == "character" or card.card_type == "event" then 394 - 14 + 2
 				else if card.card_type == "climax" then 204 - 14 + 2
 				# previous was 209
 			}

--- a/weiss2.mse-game/script
+++ b/weiss2.mse-game/script
@@ -533,7 +533,7 @@ rarity :=
 foil_shortcut :=
 {
 	if length(styling.foil_shortcut_override) > 0 then
-		styling.foil_shortcut_override
+		stlying.foil_shortcut_override
 	else if card.rarity == "SP" or card.rarity == "SSP" then
 		rarity_or_override_rarity(next_func: { card.rarity })
 	else if card.rarity == "RRR" then
@@ -849,11 +849,17 @@ replay_text_height :=
 {
 #	card_style.replay_text.content_height or else set.stylesheet.card_style.replay_text.content_height
 #	ceil(card_style.replay_text.content_lines * line_height)
-	ceil(layout_height(card_style.replay_text))
+	if styling.show_replay then
+		ceil(layout_height(card_style.replay_text))
+	else
+		0
 }
 replay_text_width :=
 {
-	(card_style.replay_text.width or else set.stylesheet.card_style.replay_text.width) - 2
+	if styling.show_replay then
+		(card_style.replay_text.width or else set.stylesheet.card_style.replay_text.width) - 2
+	else
+		0
 }
 
 replay_box_height :=

--- a/weiss2.mse-game/script
+++ b/weiss2.mse-game/script
@@ -533,7 +533,7 @@ rarity :=
 foil_shortcut :=
 {
 	if length(styling.foil_shortcut_override) > 0 then
-		stlying.foil_shortcut_override
+		styling.foil_shortcut_override
 	else if card.rarity == "SP" or card.rarity == "SSP" then
 		rarity_or_override_rarity(next_func: { card.rarity })
 	else if card.rarity == "RRR" then


### PR DESCRIPTION
In the style options, there will be a toggle to show the replay box for cards. Even if enabled, the green box will only be visible if there is text in it. Due to the nature of card style options, when switching back to the card list, it will look like the setting has been reverted, but switching to another card and then back will refresh it.